### PR TITLE
Rewrite to use an external data file, and generally reorganize into a more regimented data flow.

### DIFF
--- a/specs.data
+++ b/specs.data
@@ -6,3 +6,4 @@
 	-file: w3c/fxtf-drafts/filter-effects/Overview.bs
 +org: whatwg
 +org: wicg
+

--- a/specs.data
+++ b/specs.data
@@ -1,0 +1,8 @@
++org: w3c
+	-repo: w3c/dom
+	-repo: w3c/html
+	-repo: w3c/mnx
+	-repo: w3c/uievents
+	-file: w3c/fxtf-drafts/filter-effects/Overview.bs
++org: whatwg
++org: wicg

--- a/update.py
+++ b/update.py
@@ -78,7 +78,8 @@ def filesFromRepo(repo, skipFiles=None):
             return
         raise
     for entry in tree.tree:
-        if entry.path in skipFiles:
+        path = repo.full_name+"/"+entry.path
+        if path in skipFiles:
             print "  * Skipping file {0}".format(entry.path)
             continue
         if entry.type == 'blob' and entry.path.endswith('.bs'):
@@ -86,7 +87,7 @@ def filesFromRepo(repo, skipFiles=None):
             blob = repo.get_git_blob(entry.sha)
             assert blob.encoding == 'base64'
             text = unicode(base64.b64decode(blob.content), encoding="utf-8")
-            yield {"path": repo.full_name+"/"+entry.path, "text": text}
+            yield {"path": path, "text": text}
 
 def processFile(file):
     path = os.path.join('tests', file['path'])

--- a/update.py
+++ b/update.py
@@ -1,57 +1,118 @@
 import base64
+import io
 import os
+import re
 import sys
 
 from github import Github
+from github.GithubException import GithubException
 
-# skip files that use <pre class=include>
-# https://github.com/foolip/bikeshed-tests/issues/1
-SKIP_FILES = {
-    'w3c/dom': '*',
-    'w3c/fxtf-drafts': 'filter-effects/Overview.bs',
-    'w3c/html': '*',
-    'w3c/mnx': '*',
-    'w3c/uievents': '*',
-}
+def getData():
+    '''
+    Parses specs.data into a {orgs: [], moreRepos:[], skipRepos: [], moreFiles: [], skipFiles[]}
+    '''
+    data = {
+        "orgs": [],
+        "moreRepos": [],
+        "skipRepos": [],
+        "moreFiles": [],
+        "skipFiles": []
+    }
+    with io.open("specs.data", "r", encoding="utf-8") as fh:
+        for i,line in enumerate(fh.readlines(), 1):
+            line = line.strip()
+            if line == "":
+                # Empty lines are allowed
+                continue
+            if line.startswith("#"):
+                # Comments are allowed
+                continue
+            match = re.match(r"(\+|-)(org|repo|file):\s*([^\s].*)", line)
+            if not match:
+                raise Exception("Line {0} of the specs.data file has bad syntax.".format(i))
+            [plusMinus, type, path] = match.groups()
+            if type == "org":
+                if plusMinus == "-":
+                    raise Exception("Line {0} has a -org, which makes no sense.".format(i))
+                data['orgs'].append(path)
+            elif type =="repo":
+                if plusMinus == "+":
+                    storage = data['moreRepos']
+                else:
+                    storage = data['skipRepos']
+                storage.append(path)
+            elif type == "file":
+                if plusMinus == "+":
+                    #storage = data['moreFiles']
+                    raise Exception("Line {0} has a +file, which isn't currently supported.".format(i))
+                else:
+                    storage = data['skipFiles']
+                storage.append(path)
+    return data
 
-def process_org(org):
+
+def reposFromOrg(org, skipRepos=None):
+    if skipRepos is None:
+        skipRepos = set()
+    else:
+        skipRepos = set(skipRepos)
+    print "Searching {0} org for repositories...".format(org.login)
     for repo in org.get_repos():
-        print 'searching {}'.format(repo.full_name)
-        process_repo(repo)
+        if repo.full_name in skipRepos:
+            print "  * Skipping repo {0}".format(repo.full_name)
+            continue
+        print "  * Found repo {0}".format(repo.full_name)
+        yield repo
 
-def process_repo(repo):
+def filesFromRepo(repo, skipFiles=None):
+    if skipFiles is None:
+        skipFiles = set()
+    else:
+        skipFiles = set(skipFiles)
+    print "Searching {0} repo for Bikeshed files...".format(repo.full_name)
+
     try:
         tree = repo.get_git_tree(repo.default_branch, recursive=True)
-    except Exception as err:
+    except GithubException as err:
         if err.status == 409: # "Git Repository is empty"
             return
         raise
-    skip_files = SKIP_FILES.get(repo.full_name)
     for entry in tree.tree:
+        if entry.path in skipFiles:
+            print "  * Skipping file {0}".format(entry.path)
+            continue
         if entry.type == 'blob' and entry.path.endswith('.bs'):
-            if skip_files == '*' or skip_files == entry.path:
-                print '  skipping {}'.format(entry.path)
-                continue
-
-            print '  found {}'.format(entry.path)
-
+            print "  * Found file {0}".format(entry.path)
             blob = repo.get_git_blob(entry.sha)
             assert blob.encoding == 'base64'
-            text = base64.b64decode(blob.content)
+            text = unicode(base64.b64decode(blob.content), encoding="utf-8")
+            yield {"path": repo.full_name+"/"+entry.path, "text": text}
 
-            path = os.path.join('tests', repo.full_name, entry.path)
-            dirname = os.path.dirname(path)
-            if not os.path.exists(dirname):
-                os.makedirs(dirname)
-            with open(path, 'w+') as f:
-                f.write(text)
+def processFile(file):
+    path = os.path.join('tests', file['path'])
+    print "Saving file {0}".format(path)
+    dirname = os.path.dirname(path)
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
+    with io.open(path, 'w+', encoding="utf-8") as f:
+        f.write(file['text'])
+
 
 def main():
     token = os.environ['GH_TOKEN']
     g = Github(token)
-    for name in ['w3c', 'whatwg', 'wicg']:
-        org = g.get_organization(name)
-        process_org(org)
+    data = getData()
+    repos = []
+    for orgName in sorted(data['orgs']):
+        org = g.get_organization(orgName)
+        repos.extend(reposFromOrg(org, data['skipRepos']))
+    for repoName in data['moreRepos']:
+        repos.append(g.get_repo(repoName))
+    files = []
+    for repo in sorted(repos, key=lambda x:x.full_name):
+        files.extend(filesFromRepo(repo, data['skipFiles']))
+    for file in sorted(files, key=lambda x:x['path']):
+        processFile(file)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
(Fixes #2.)

The new data format is a line-based format, which should be easy to read and PR.

Each line looks like `+org: w3c`:

* you can use `+` to add things to the set of explored stuff, or `-` to skip them
* you can specify `org`, `repo`, or `file`, with the values after being the path segment following after `github.com`

(Currently `-org` isn't supported, since it's useless, and `+file` isn't supported because I haven't figured it out yet.)

Whitespace around the line is ignored; I'm using indentation as a readability aid, to nest skipped repos/files under the org we've added.

Comments are also allowed - any line starting with a `#` is a comment and is ignored.  Blank lines are also ignored.

(This should probably be written into a README.)

---

The overall data flow has also been more regimented - first I walk all the orgs to find repos we should search, then we search all the repos to find files we should grab, then we grab all the files.  This is done in three distinct phases to make it easier to add arbitrary repos/files, which seems like it should probably be useful.